### PR TITLE
feat: Move card to bottom of list

### DIFF
--- a/src/app/app.go
+++ b/src/app/app.go
@@ -5,7 +5,6 @@ import (
 	"landau/agile-results/src/ollert"
 	"landau/agile-results/src/prompt"
 
-	"github.com/adlio/trello"
 	"github.com/sirupsen/logrus"
 )
 
@@ -64,11 +63,8 @@ func RunApp(config *Config) (ollert.ICard, error) {
 
 	logrus.Debugf("Selected %d labels: %v", len(selectedLabels), selectedLabels)
 
-	// FIXME: This should put the card at the end of  the list.
-	// err = card.MoveToBottomOfList() // TODO: add test using ICard
-
 	card, err := client.CreateCard(
-		&trello.Card{
+		&ollert.TrelloCardConfig{
 			IDList:   config.ListID,
 			Name:     cardName,
 			IDLabels: selectedLabels,
@@ -79,6 +75,8 @@ func RunApp(config *Config) (ollert.ICard, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	err = card.MoveToBottomOfList()
 
 	if config.HasChecklist {
 		items, err := prompter.PromptList("Checklist Items: ")

--- a/src/ollert/card.go
+++ b/src/ollert/card.go
@@ -1,6 +1,8 @@
 package ollert
 
-import "github.com/adlio/trello"
+import (
+	"github.com/adlio/trello"
+)
 
 // ICard -
 type ICard interface {
@@ -50,4 +52,77 @@ func (c *Card) IDLabels() []string {
 // NewCard - Use this to create a new Trello Card
 func NewCard(c *trello.Card) ICard {
 	return &Card{card: c}
+}
+
+type (
+	// MockCardConfig -
+	MockCardConfig struct {
+		TrelloCardConfig
+		ID       string
+		Name     string
+		Card     *trello.Card
+		ShortURL string
+		IDLabels []string
+		IDList   string
+
+		// Methods
+		MoveToBottomOfListReturnValue error
+	}
+
+	// MockCard -
+	MockCard struct {
+		id       string
+		name     string
+		card     *trello.Card
+		shortURL string
+		idLabels []string
+
+		// Mocked methods
+		MoveToBottomOfListCallCount   int
+		moveToBottomOfListReturnValue error
+	}
+)
+
+// MoveToBottomOfList -
+func (c *MockCard) MoveToBottomOfList() error {
+	c.MoveToBottomOfListCallCount++
+	return c.moveToBottomOfListReturnValue
+}
+
+// Card -
+func (c *MockCard) Card() *trello.Card {
+	return c.card
+}
+
+// ID -
+func (c *MockCard) ID() string {
+	return c.id
+}
+
+// Name -
+func (c *MockCard) Name() string {
+	return c.name
+}
+
+// ShortURL -
+func (c *MockCard) ShortURL() string {
+	return c.shortURL
+}
+
+// IDLabels -
+func (c *MockCard) IDLabels() []string {
+	return c.idLabels
+}
+
+// NewMockCard - Use this to create a new Trello MockCard
+func NewMockCard(c *MockCardConfig) *MockCard {
+	return &MockCard{
+		id:       c.ID,
+		name:     c.Name,
+		card:     c.Card,
+		shortURL: c.ShortURL,
+		idLabels: c.IDLabels,
+
+		moveToBottomOfListReturnValue: c.MoveToBottomOfListReturnValue,
+	}
 }

--- a/src/ollert/client.go
+++ b/src/ollert/client.go
@@ -7,7 +7,7 @@ import (
 
 // IClient - interface for client
 type IClient interface {
-	CreateCard(card *trello.Card, args trello.Arguments) (ICard, error)
+	CreateCard(cardConfig *TrelloCardConfig, args trello.Arguments) (ICard, error)
 	GetBoard(boardID string, args trello.Arguments) (IBoard, error)
 	CreateChecklist(card ICard, name string, items []string, args trello.Arguments) (IChecklist, error)
 }
@@ -31,7 +31,8 @@ func (c *Client) GetBoard(boardID string, args trello.Arguments) (IBoard, error)
 }
 
 // CreateCard -
-func (c *Client) CreateCard(card *trello.Card, args trello.Arguments) (ICard, error) {
+func (c *Client) CreateCard(cardConfig *TrelloCardConfig, args trello.Arguments) (ICard, error) {
+	card := NewTrelloCard(cardConfig)
 	err := c.client.CreateCard(card, args)
 
 	if err != nil {
@@ -105,7 +106,7 @@ type (
 
 	// CreateCardCall -
 	CreateCardCall struct {
-		Card *trello.Card
+		Card ICard
 		Args trello.Arguments
 	}
 
@@ -137,7 +138,12 @@ func (c *MockClient) GetBoard(boardID string, args trello.Arguments) (IBoard, er
 }
 
 // CreateCard -
-func (c *MockClient) CreateCard(card *trello.Card, args trello.Arguments) (ICard, error) {
+func (c *MockClient) CreateCard(cardConfig *TrelloCardConfig, args trello.Arguments) (ICard, error) {
+	card := NewMockCard(&MockCardConfig{
+		ID:       cardConfig.ID,
+		Name:     cardConfig.Name,
+		IDLabels: cardConfig.IDLabels,
+	})
 	c.CreateCardCalls = append(c.CreateCardCalls, CreateCardCall{Card: card, Args: args})
 
 	// If a user needs to specify a card returned, then use this pathway
@@ -145,7 +151,7 @@ func (c *MockClient) CreateCard(card *trello.Card, args trello.Arguments) (ICard
 		return c.createCardReturn.Card, c.createCardReturn.Err
 	}
 
-	return NewCard(card), c.createCardReturn.Err
+	return card, c.createCardReturn.Err
 }
 
 // CreateChecklist -

--- a/src/ollert/trello_card.go
+++ b/src/ollert/trello_card.go
@@ -1,0 +1,23 @@
+package ollert
+
+import (
+	"github.com/adlio/trello"
+)
+
+// TrelloCardConfig -
+type TrelloCardConfig struct {
+	ID       string
+	Name     string
+	IDLabels []string
+	IDList   string
+}
+
+// NewTrelloCard -
+func NewTrelloCard(c *TrelloCardConfig) *trello.Card {
+	return &trello.Card{
+		ID:       c.ID,
+		Name:     c.Name,
+		IDLabels: c.IDLabels,
+		IDList:   c.IDList,
+	}
+}


### PR DESCRIPTION
The main idea of this PR is to continue peeling away the `trello` api usage from the app. In order to test moving the card to the bottom, I stripped out the `trello.Card` and instead provide a `TrelloCardConfig` which any `IClient` accepts as input to the `CreateCard` method. This enables the mock client to behave in an expected manner.